### PR TITLE
Google maps service spike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 
 # SimpleCov test coverage data folder
 coverage
+
+# Ignore application configuration
+/config/application.yml

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# SimpleCov test coverage data folder
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ coverage
 
 # Ignore application configuration
 /config/application.yml
+
+# Ignore API mock stubs stored with VCR gem
+/spec/cassettes

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem 'faraday'
 # Figaro - ENV variable gem
 gem 'figaro'
 
+# Polyline to help decode GoogleMaps polylines into long lat coords
+gem 'polylines'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,12 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
+# Faraday - Http requests gem
+gem 'faraday'
+
+# Figaro - ENV variable gem
+gem 'figaro'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,13 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'webdrivers'
   gem 'webmock'
+
+  # FIXME: Force bundler to use the beta version of the hashdiff gem
+  #        `hashdiff` is a dependency of the `webmock` gem. Feel free to remove
+  #        the following line from this Gemfile as soon as hashdiff 1.0.0 is
+  #        officially realized.
+  # https://stackoverflow.com/questions/57004493/ruby-gem-hashdiff-how-to-upgrade-to-1-0-to-stop-deprecation-warnings
+  gem 'hashdiff', '>= 1.0.0.beta1'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    hashdiff (0.4.0)
+    hashdiff (1.0.0.beta1)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     json (2.2.0)
@@ -204,6 +204,7 @@ DEPENDENCIES
   byebug
   capybara
   factory_bot_rails
+  hashdiff (>= 1.0.0.beta1)
   launchy
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,11 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
+    figaro (1.1.1)
+      thor (~> 0.14)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.0.beta1)
@@ -98,6 +102,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.3.0)
+    multipart-post (2.1.1)
     nio4r (2.4.0)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -204,6 +209,8 @@ DEPENDENCIES
   byebug
   capybara
   factory_bot_rails
+  faraday
+  figaro
   hashdiff (>= 1.0.0.beta1)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
+    polylines (0.3.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -215,6 +216,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
+  polylines
   pry
   puma (~> 3.11)
   rails (~> 5.2.3)

--- a/app/services/google_maps_service.rb
+++ b/app/services/google_maps_service.rb
@@ -1,0 +1,22 @@
+class GoogleMapsService
+  attr_reader :origin, :destination
+
+  def initialize(origin, destination)
+    @origin = origin
+    @destination = destination
+  end
+
+  def conn
+    @_conn ||= Faraday.new('https://maps.googleapis.com/maps/api/directions/json') do |f|
+      f.adapter Faraday.default_adapter
+      f.params['key'] = ENV['GOOGLE_MAPS_APIKEY']
+    end
+  end
+
+  def response
+    @_response ||= conn.get do |req|
+      req.params['origin'] = origin
+      req.params['destination'] = destination
+    end
+  end
+end

--- a/app/services/google_maps_service.rb
+++ b/app/services/google_maps_service.rb
@@ -19,4 +19,24 @@ class GoogleMapsService
       req.params['destination'] = destination
     end
   end
+
+  def json
+    JSON.parse(response.body)
+  end
+
+  def steps
+    json['routes'][0]['legs'][0]['steps']
+  end
+
+  def route_coordinates
+    coordinates = []
+
+    steps.each do |step|
+      polyline = step['polyline']['points']
+      p_decoded = Polylines::Decoder.decode_polyline(polyline)    # Gem that decodes polyline string into an array of long/lat coords
+      coordinates += p_decoded
+    end
+
+    coordinates
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,7 +9,14 @@ require 'rspec/rails'
 
 # SimpleCov configuration
 require 'simplecov'
-SimpleCov.start 'rails'
+SimpleCov.start 'rails' do
+  add_filter "/app/channels/application_cable/channel.rb"
+  add_filter "/app/channels/application_cable/connection.rb"
+  add_filter "/app/controllers/application_controller.rb"
+  add_filter "/app/jobs/application_job.rb"
+  add_filter "/app/mailers/application_mailer.rb"
+  add_filter "/app/models/application_record.rb"
+end
 
 # Adds API mock/stub fixture tools configuration
 require 'vcr'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ VCR.configure do |config|
   config.cassette_library_dir = 'spec/cassettes'
   config.hook_into :webmock
   config.configure_rspec_metadata!
-  config.filter_sensitive_data('<DARK_SKY_API>') { ENV['DARK_SKY_API'] }
+  config.filter_sensitive_data('<GOOGLE_MAPS_APIKEY>') { ENV['GOOGLE_MAPS_APIKEY'] }
 
   config.ignore_hosts(
     'chromedriver.storage.googleapis.com',

--- a/spec/services/google_maps_service_spec.rb
+++ b/spec/services/google_maps_service_spec.rb
@@ -1,14 +1,19 @@
 require 'rails_helper'
 
 describe 'Google Maps Service Spec' do
-  it 'returns data' do
+  it 'returns array of longitude latitude points along route' do
    VCR.use_cassette("services/google_maps/directions") do
       origin = 'Denver,CO'
       destination = 'Seattle,WA'
 
       gs = GoogleMapsService.new(origin, destination)
+      route_coordinates = gs.route_coordinates
 
-      expect(gs.response).to eq('blah')
+      expect(route_coordinates).to         be_an(Array)
+      expect(route_coordinates.length).to  eq(41778)
+
+      expect(route_coordinates.first).to   eq([39.74116, -104.98791])
+      expect(route_coordinates.last).to    eq([47.60637999999997, -122.33223000000001])
     end
   end
 end

--- a/spec/services/google_maps_service_spec.rb
+++ b/spec/services/google_maps_service_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'Google Maps Service Spec' do
+  it 'returns data' do
+   VCR.use_cassette("services/google_maps/directions") do
+      origin = 'Denver,CO'
+      destination = 'Seattle,WA'
+
+      gs = GoogleMapsService.new(origin, destination)
+
+      expect(gs.response).to eq('blah')
+    end
+  end
+end


### PR DESCRIPTION
Adds Google Maps service spike, specifically this service is using the [Google Directions API](https://developers.google.com/maps/documentation/directions/start).  
closes #6 

I wanted to experiment with polylines to see if it is possible to return an array of longitude/latitude coordinates along a route. It is, although between Denver and Seattle it returns 41_778 sets of coordinates so I am still thinking of how we could use this or if we should go a different 'direction' :)

The service takes two string arguments: origin and destination. The Google directions API returns turn by turn data for driving directions between the origin and destination locations.

In doing so, the following configuration was required.  Even if we do not use this service, at least these tools are configured for other external API consumption now...

1. Setup database (even though there is no schema, it was required for running RSpec)
2. Faraday gem was added for HTTP requests
3. Figaro gem was added for ENV variable management. 
NOTE: to setup Figaro on your local machine, run command: `$ bundle exec figaro install` and then add `GOOGLE_MAPS_APIKEY` to your application.yml file.
4. Polylines gem added as a tool to decode polyline strings into longitude latitude coordinates
5. SimpleCov configuration to filter files that we do not need to track for test coverage.

Google Polylines reference: https://developers.google.com/maps/documentation/utilities/polylinealgorithm?csw=1