### PR TITLE
Add poi columns

### DIFF
--- a/app/models/poi.rb
+++ b/app/models/poi.rb
@@ -2,7 +2,8 @@ class Poi < ApplicationRecord
   has_many :trip_pois
   has_many :trips, through: :trip_pois
 
-  validates_presence_of :name,
+  validates_presence_of :name, :population, :state,
+                        :land_area, :total_area,
                         :ne_latitude, :ne_longitude,
                         :sw_latitude, :sw_longitude
 end

--- a/db/migrate/20190715225107_add_descriptive_columns_to_poi.rb
+++ b/db/migrate/20190715225107_add_descriptive_columns_to_poi.rb
@@ -1,0 +1,8 @@
+class AddDescriptiveColumnsToPoi < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pois, :population, :integer
+    add_column :pois, :state, :string
+    add_column :pois, :land_area, :integer
+    add_column :pois, :total_area, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_14_230937) do
+ActiveRecord::Schema.define(version: 2019_07_15_225107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,10 @@ ActiveRecord::Schema.define(version: 2019_07_14_230937) do
     t.float "sw_longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "population"
+    t.string "state"
+    t.integer "land_area"
+    t.integer "total_area"
   end
 
   create_table "trip_pois", force: :cascade do |t|


### PR DESCRIPTION
Adds four columns to the `pois` table:
- population: integer
- state: string
- land_area: integer
- total_area: integer


- Adds validation testing for new columns

closes #25 