### PR TITLE
Poi at Location

### DIFF
--- a/app/models/poi.rb
+++ b/app/models/poi.rb
@@ -6,4 +6,12 @@ class Poi < ApplicationRecord
                         :land_area, :total_area,
                         :ne_latitude, :ne_longitude,
                         :sw_latitude, :sw_longitude
+
+  def self.poi_at_location(lat, lng)
+    Poi
+      .where('ne_latitude > ?', lat)
+      .where('sw_latitude < ?', lat)
+      .where( 'sw_longitude < ?', lng)
+      .where('ne_longitude > ?', lng)
+  end
 end

--- a/app/models/poi.rb
+++ b/app/models/poi.rb
@@ -9,9 +9,9 @@ class Poi < ApplicationRecord
 
   def self.poi_at_location(lat, lng)
     Poi
-      .where('ne_latitude > ?', lat)
-      .where('sw_latitude < ?', lat)
-      .where( 'sw_longitude < ?', lng)
-      .where('ne_longitude > ?', lng)
+      .where('ne_latitude >= ?', lat)
+      .where('sw_latitude <= ?', lat)
+      .where( 'sw_longitude <= ?', lng)
+      .where('ne_longitude >= ?', lng)
   end
 end

--- a/spec/factories/pois.rb
+++ b/spec/factories/pois.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     ne_longitude { 1.5 }
     sw_latitude { 1.5 }
     sw_longitude { 1.5 }
+    population { 1000 }
+    state { "CO" }
+    land_area { "2500" }
+    total_area { "3000" }
   end
 end

--- a/spec/models/poi_spec.rb
+++ b/spec/models/poi_spec.rb
@@ -47,7 +47,12 @@ RSpec.describe Poi, type: :model do
       it 'can return no poi' do
         zero_poi = Poi.poi_at_location(-1,-1)
         expect(zero_poi.length).to eq(0)
+      end
 
+      it 'returns poi if on edge' do
+        one_poi = Poi.poi_at_location(0,0)
+        expect(one_poi.length).to eq(1)
+        expect(one_poi[0]).to eq(@poi_1)
       end
     end
   end

--- a/spec/models/poi_spec.rb
+++ b/spec/models/poi_spec.rb
@@ -17,4 +17,38 @@ RSpec.describe Poi, type: :model do
     it { should have_many :trip_pois }
     it { should have_many(:trips).through(:trip_pois) }
   end
+
+  describe 'Class Methods' do
+    describe 'poi_at_location' do
+
+      before :each do
+        @poi_1 = create(:poi,
+          sw_latitude: 0, sw_longitude: 0,ne_latitude: 2, ne_longitude: 2
+        )
+        @poi_2 = create(:poi,
+          sw_latitude: 1, sw_longitude: 1,ne_latitude: 3, ne_longitude: 3
+        )
+      end
+      it 'can return a single poi' do
+        single_poi = Poi.poi_at_location(0.5, 0.5)
+        expect(single_poi).to have(1).items
+        expect(single_poi[0]).to eq(@poi_1)
+      end
+
+      it 'can return multiple poi' do
+        multiple_poi = Poi.poi_at_location(1.5, 1.5)
+        expect(multiple_poi).to have(2).items
+
+        expect(multiple_poi).to include(@poi_1)
+        expect(multiple_poi).to include(@poi_2)
+
+      end
+
+      it 'can return no poi' do
+        zero_poi = Poi.poi_at_location(-1,-1)
+        expect(zero_poi).to have(0).items
+
+      end
+    end
+  end
 end

--- a/spec/models/poi_spec.rb
+++ b/spec/models/poi_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe Poi, type: :model do
       end
       it 'can return a single poi' do
         single_poi = Poi.poi_at_location(0.5, 0.5)
-        expect(single_poi).to have(1).items
+        expect(single_poi.length).to eq(1)
         expect(single_poi[0]).to eq(@poi_1)
       end
 
       it 'can return multiple poi' do
         multiple_poi = Poi.poi_at_location(1.5, 1.5)
-        expect(multiple_poi).to have(2).items
+        expect(multiple_poi.length).to eq(2)
 
         expect(multiple_poi).to include(@poi_1)
         expect(multiple_poi).to include(@poi_2)
@@ -46,7 +46,7 @@ RSpec.describe Poi, type: :model do
 
       it 'can return no poi' do
         zero_poi = Poi.poi_at_location(-1,-1)
-        expect(zero_poi).to have(0).items
+        expect(zero_poi.length).to eq(0)
 
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -94,6 +94,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Enable FactoryBot in tests
+  config.include FactoryBot::Syntax::Methods
+
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
Creates class method `Poi.poi_at_location(lat, lng)`

Returns an ActiveRecord relation including all of the Poi that encompass the query point.

Adds FactoryBot to `rails_helper`
Adds updated attributes to Poi FactoryBot 

closes #21 

Test coverage 100%