### PR TITLE
Adss forecast serializer gsub of weather icon dashes to underscores

### DIFF
--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -11,7 +11,7 @@ class ForecastSerializer
     return {
       'time' =>              c['time'],
       'summary' =>           c['summary'],
-      'icon' =>              c['icon'],
+      'icon' =>              c['icon'].gsub('-', '_'),
       'temperature' =>       c['temperature'],
       'precipProbability' => c['precipProbability'],
       'precipIntensity' =>   c['precipIntensity'],
@@ -33,7 +33,7 @@ class ForecastSerializer
     return {
       'time' =>              h['time'],
       'summary' =>           h['summary'],
-      'icon' =>              h['icon'],
+      'icon' =>              h['icon'].gsub('-', '_'),
       'temperature' =>       h['temperature'],
       'precipProbability' => h['precipProbability'],
       'precipIntensity' =>   h['precipIntensity'],

--- a/spec/serializers/forecast_serializer_spec.rb
+++ b/spec/serializers/forecast_serializer_spec.rb
@@ -99,6 +99,42 @@ describe 'Forecast Serializer Spec' do
     expect(forecast_in_1_hour['windBearing']).to        be_a(Float).or(be_an(Integer))
   end
 
+  it 'icons Happy Path - substitutes dashes with underscores' do
+    forecast_json = {
+      "currently" => {
+        "icon" => "partly-cloudy-day"
+        },
+      "hourly" => {
+        "data" => [{
+          "icon" => "clear-night"
+        }]
+      }
+    }
+
+    fs = ForecastSerializer.new(forecast_json)
+
+    expect(fs.currently['icon']).to eq('partly_cloudy_day')
+    expect(fs.hourly_in(0)['icon']).to eq('clear_night')
+  end
+
+  it 'icons Sad Path - does not parse icons with no dashes' do
+    forecast_json = {
+      "currently" => {
+        "icon" => "rain"
+        },
+      "hourly" => {
+        "data" => [{
+          "icon" => "snow"
+        }]
+      }
+    }
+
+    fs = ForecastSerializer.new(forecast_json)
+
+    expect(fs.currently['icon']).to eq('rain')
+    expect(fs.hourly_in(0)['icon']).to eq('snow')
+  end
+
   it 'Sad path - Dark Sky API only returns hourly up to 48 hours' do
     forecast_in_49_hours = @fs.hourly_in(49)
 


### PR DESCRIPTION
- Updates forecast serializer to gsub dashes in the weather `icon` per request from front end team.

- Includes new tests for icons with and without dashes

closes #38 