### PR TITLE
Trip facade renaming

### DIFF
--- a/app/controllers/api/v1/trips_controller.rb
+++ b/app/controllers/api/v1/trips_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::TripsController < ActionController::API
   def create
-    render json: TripFacade.new(trip_params).response, status: 201
+    render json: InitialTripFacade.new(trip_params).response, status: 201
   end
 
   def index

--- a/app/controllers/api/v1/trips_controller.rb
+++ b/app/controllers/api/v1/trips_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::TripsController < ActionController::API
 
     # If valid trip AND trip.status == "Ready", return all POIs and Legs
     elsif trip.ready?
-      render json: TripLegsFacade.new(trip).response, status: 200
+      render json: FullTripFacade.new(trip).response, status: 200
     end
   end
 

--- a/app/facades/full_trip_facade.rb
+++ b/app/facades/full_trip_facade.rb
@@ -1,4 +1,4 @@
-class TripLegsFacade
+class FullTripFacade
   def initialize(trip)
     @trip = trip
   end

--- a/app/facades/initial_trip_facade.rb
+++ b/app/facades/initial_trip_facade.rb
@@ -1,4 +1,4 @@
-class TripFacade
+class InitialTripFacade
   attr_reader :origin, :destination, :trip
 
   def initialize(trip_params)

--- a/spec/facades/trip_legs_facade_spec.rb
+++ b/spec/facades/trip_legs_facade_spec.rb
@@ -48,7 +48,7 @@ describe 'Trip Legs Facade spec' do
   end
   it 'Builds a response of trip data on places' do
     VCR.use_cassette("facades/trip_legs_facade/places") do
-      places = TripLegsFacade.new(@trip).places
+      places = FullTripFacade.new(@trip).places
 
       expect(places).to be_an(Array)
       expect(places.length).to eq(@trip.pois.length)
@@ -66,7 +66,7 @@ describe 'Trip Legs Facade spec' do
 
   it 'Builds a response of trip data on legs' do
     VCR.use_cassette("facades/trip_legs_facade/legs") do
-      legs = TripLegsFacade.new(@trip).legs
+      legs = FullTripFacade.new(@trip).legs
 
       expect(legs).to        be_an Array
       expect(legs.length).to eq(@trip.trip_legs.length)
@@ -80,7 +80,7 @@ describe 'Trip Legs Facade spec' do
 
   it 'Builds a response combining the poi and leg data' do
     VCR.use_cassette("facades/trip_legs_facade/response") do
-      response = TripLegsFacade.new(@trip).response
+      response = FullTripFacade.new(@trip).response
 
       expect(response).to        be_a Hash
       expect(response[:data]).to be_a Hash


### PR DESCRIPTION
- [x] Check this if the PR has been approved by the team to be a quick patch and the rest of this form will not be filled out

## What functionality does this accomplish?
closes #70

**Description:**
Renames the two trip facades for to be more clear what they are for.

- TripFacade is now InitialTripFacade

- TripLegsFacade is now FullTripFacade
