### PR TITLE
Adds REDIS_URL config for Heroku

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,2 @@
+#Heroku Redis Configuration - https://devcenter.heroku.com/articles/heroku-redis#connecting-in-ruby
+$redis = Redis.new(url: ENV["REDIS_URL"])


### PR DESCRIPTION
- [x] Check this if the PR has been approved by the team to be a quick patch and the rest of this form will not be filled out

## What functionality does this accomplish?
closes #

**Description:**
Adds missing REDIS_URL config for Redis on Rails/Heroku

## Helpful Resources:
* Resource link AND small description of info gathered/learned

https://devcenter.heroku.com/articles/heroku-redis#connecting-in-rails
https://devcenter.heroku.com/articles/heroku-redis#connecting-in-ruby

## Review Requests(optional):


## Co-Authors (optional):


## Please include an emoji of how you feel about this branch:
